### PR TITLE
Regex and workflow failure fix

### DIFF
--- a/.github/workflows/profiles-sync.yml
+++ b/.github/workflows/profiles-sync.yml
@@ -103,7 +103,8 @@ jobs:
             sync
 
       - name: Merge PR
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' 
+          && (steps.pr.outputs.pull-request-operation == 'created' || steps.pr.outputs.pull-request-operation == 'updated' || steps.pr.outputs.pull-request-number)
         run: |
           gh pr merge ${{ steps.pr.outputs.pull-request-number }} --auto --squash --delete-branch
         env:

--- a/scripts/trash_profile_parser.py
+++ b/scripts/trash_profile_parser.py
@@ -23,7 +23,7 @@ def write_regex_pattern_file(template_directory, regex_pattern_directory, regex_
     regex_template = load_template(template_directory / "regexPattern.yml")
     regex_template['name'] = regex_pattern_filename
     regex_template['description'] = ''
-    regex_template['pattern'] = regex_pattern
+    regex_template['pattern'] = repr(regex_pattern)[1:-1]
     regex_template['tags'] = [ 'TRaSH' ]
     regex_template['tests'] = []
 


### PR DESCRIPTION
This update fixes the regex parsing from the TRaSH profiles, as it was reading the double backslashes as singles - leading to potentially unwanted behaviour (observed in Sonarr instance). The observed issue may not be fixed with this, but is definitely a step closer.

This also addresses the issue of "failed" workflow runs when the auto-merge PR step isn't able to complete when there exists no PR. It has now been set to only run the step if there is actually anything to work with.